### PR TITLE
Static cast from optional to bool

### DIFF
--- a/assembler/src/common/assembly_graph/paths/mapping_path.hpp
+++ b/assembler/src/common/assembly_graph/paths/mapping_path.hpp
@@ -387,7 +387,7 @@ public:
     }
 
     bool has_filling() const {
-        return filling_seq_;
+        return static_cast<bool>(filling_seq_);
     }
 
     Sequence filling_seq() const {


### PR DESCRIPTION
GCC 8 release candidate 2 fails to build spades 3.11.1 with the following error:

```
/tmp/spades-20180501-70617-jseptw/SPAdes-3.11.1/src/common/assembly_graph/paths/mapping_path.hpp:390:16: error: cannot convert 'const boost::optional<Sequence>' to 'bool' in return
         return filling_seq_;
                ^~~~~~~~~~~~
```

A static cast to `bool` is the correct way to go.