### PR TITLE
plasmid_glue_contigs.py added to CMakeLists.txt

### DIFF
--- a/assembler/src/plasmid_utils/plasmidverify.py
+++ b/assembler/src/plasmid_utils/plasmidverify.py
@@ -1,5 +1,3 @@
-
-
 #!/usr/bin/env python
 
 import os, errno

--- a/assembler/src/spades_pipeline/CMakeLists.txt
+++ b/assembler/src/spades_pipeline/CMakeLists.txt
@@ -8,7 +8,7 @@
 project(spades_pipeline)
 
 # SPAdes pipeline scripts
-install(FILES hammer_logic.py process_cfg.py spades_logic.py corrector_logic.py support.py options_storage.py lucigen_nxmate.py
+install(FILES hammer_logic.py process_cfg.py spades_logic.py corrector_logic.py support.py options_storage.py lucigen_nxmate.py plasmid_glue_contigs.py
         DESTINATION share/spades/spades_pipeline
         COMPONENT runtime)
 # TruSpades module


### PR DESCRIPTION
- Fix `No module named plasmid_glue_contigs error` in spades.py
- Remove empty lines in plasmidverify.py