### PR TITLE
typo pac_index.hpp: splitted -> split

### DIFF
--- a/assembler/src/common/modules/alignment/pacbio/pac_index.hpp
+++ b/assembler/src/common/modules/alignment/pacbio/pac_index.hpp
@@ -65,7 +65,7 @@ class PacBioMappingIndex {
                     auto next_iter = iter + 1;
                     if (next_iter == path.end() || !IsConsistent(*iter, *next_iter)) {
                         if (next_iter != path.end()) {
-                            DEBUG("clusters splitted:");
+                            DEBUG("clusters split:");
                             DEBUG("on " << iter->str(g_));
                             DEBUG("and " << next_iter->str(g_));
                         }


### PR DESCRIPTION
Found by Michael Crusoe while curating the Debian package