### PR TITLE
typo hamcluster.cpp: spliting -> splitting

### DIFF
--- a/assembler/src/projects/hammer/hamcluster.cpp
+++ b/assembler/src/projects/hammer/hamcluster.cpp
@@ -173,7 +173,7 @@ void KMerHamClusterer::cluster(const std::string &prefix,
 
   size_t big_blocks2 = 0;
   {
-    INFO("Spliting sub-kmers, pass 2.");
+    INFO("Splitting sub-kmers, pass 2.");
     SubKMerSplitter Splitter(bfname, kfname);
     size_t nblocks = 0;
     std::pair<size_t, size_t> stat =


### PR DESCRIPTION
Found by Michael Crusoe while curating the Debian package