### PR TITLE
Make checks for extension case-insensitive

### DIFF
--- a/assembler/src/projects/mts/Common.snake
+++ b/assembler/src/projects/mts/Common.snake
@@ -121,10 +121,7 @@ def is_fastq(wildcards):
     name = getattr(wildcards, "sample", None)
     if not name:
         name = GROUPS[wildcards.group][0]
-    for ext in {".fastq", ".fq", ".fastq.gz", "fq.gz"}:
-        if SAMPLE_READS[name][0].endswith(ext):
-            return True
-    return False
+    return SAMPLE_READS[name][0].lower().endswith((".fastq", ".fq", ".fastq.gz", "fq.gz"))
 
 rule combine_samples:
     input:   expand("{{dir}}/{group}.fasta", group=sorted(GROUPS))

--- a/assembler/src/spades_pipeline/common/SeqIO.py
+++ b/assembler/src/spades_pipeline/common/SeqIO.py
@@ -14,7 +14,7 @@ fastq_ext = ['.fq', '.fastq']
 
 
 def Open(f, mode):
-    if f.endswith(".gz") or f.endswith(".gzip"):
+    if f.lower().endswith((".gz", ".gzip")):
         return codecs.getreader('UTF-8')(gzip.open(f, mode))
     else:
         return codecs.open(f, mode, encoding='utf-8')
@@ -159,9 +159,10 @@ def RemoveNs(input_handler, output_handler):
 
 
 def check_extension(fname, extension_list):
+    fname = fname.lower()
     # "reads.fastq", ".gz"
     basename_plus_innerext, outer_ext = os.path.splitext(fname)
-    if not outer_ext in ['.gz', '.gzip']:
+    if outer_ext not in ['.gz', '.gzip']:
         basename_plus_innerext, outer_ext = fname, ''  # not an archive
 
     # "reads", ".fastq"


### PR DESCRIPTION
Hi!
I encountered an error "incorrect extension of reads file" when I passed a .fastQ file to spades. 
I don't thinks it was an intended behavior, so here is the fix.

I also found the same issue in mts project.
I'm not sure that I found all places that check extensions in the project. If you know about other places that I can fix, please tell me.