### PR TITLE
Removed the second parse function (without check for allowed file types)

### DIFF
--- a/assembler/src/spades_pipeline/common/SeqIO.py
+++ b/assembler/src/spades_pipeline/common/SeqIO.py
@@ -122,13 +122,6 @@ def parse_fastq(handler):
         yield SeqRecord(rec_seq, rec_id[1:], rec_qual)
 
 
-def parse(handler, file_type):
-    if file_type == "fasta":
-        return parse_fasta(handler)
-    elif file_type == "fastq":
-        return parse_fastq(handler)
-
-
 def write(rec, handler, file_type):
     if file_type == "fasta":
         handler.write(">" + rec.id + "\n")


### PR DESCRIPTION
There are two functions with the same name (parse) and almost the same content in the module.

[The first function](https://github.com/bondarevts/spades/blob/8d13ac08916ca2612ece5e882fe0d8c21b76d359/assembler/src/spades_pipeline/common/SeqIO.py#L96-L101) is safer (it checks for allowed file types and fails early). It is never used because it's overridden by the second implementation.

I guess that [the second function](https://github.com/bondarevts/spades/blob/8d13ac08916ca2612ece5e882fe0d8c21b76d359/assembler/src/spades_pipeline/common/SeqIO.py#L125-L129) can be safely removed (if there are no calls with wrong arguments.