### PR TITLE
Cmake version specified is incorrect (needs 3.5, not 2.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Just as in Linux, SPAdes is ready to use and no further installation steps are r
 If you wish to compile SPAdes by yourself you will need the following libraries to be pre-installed:
 
 -   g++ (version 5.3.1 or higher)
--   cmake (version 2.8.12 or higher)
+-   cmake (version 3.5 or higher)
 -   zlib
 -   libbz2
 


### PR DESCRIPTION
I tried to install this program using cmake 3.4.3 and got an error:

CMake Error at CMakeLists.txt:10 (cmake_minimum_required):
  CMake 3.5 or higher is required.  You are running version 3.4.3

The files in this very repo support this version requirement:

https://github.com/ablab/spades/blob/spades_3.14.1/assembler/src/CMakeLists.txt

cmake_minimum_required(VERSION 3.5)