### PR TITLE
#include <stdint.h>

### DIFF
--- a/assembler/ext/src/bamtools/api/internal/io/pbgzf/util.c
+++ b/assembler/ext/src/bamtools/api/internal/io/pbgzf/util.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <pthread.h>


### PR DESCRIPTION
`<stdint.h>` needs to be included in some environments (e.g. Alpine Linux with `musl-dev` and `g++`) to have `int32_t` type defined