### PR TITLE
#include <stdint.h>

### DIFF
--- a/assembler/src/common/sequence/seq_common.hpp
+++ b/assembler/src/common/sequence/seq_common.hpp
@@ -18,7 +18,7 @@
 #include "k_range.hpp"
 #include <cstdint>
 
-typedef u_int64_t seq_element_type;
+typedef uint64_t seq_element_type;
 
 constexpr size_t t_size(void) {
     return sizeof(seq_element_type);

--- a/assembler/src/common/sequence/seq_common.hpp
+++ b/assembler/src/common/sequence/seq_common.hpp
@@ -15,8 +15,8 @@
 #ifndef SEQ_COMMON_HPP_
 #define SEQ_COMMON_HPP_
 
-#include <stdint.h>
 #include "k_range.hpp"
+#include <cstdint>
 
 typedef u_int64_t seq_element_type;
 

--- a/assembler/src/common/sequence/seq_common.hpp
+++ b/assembler/src/common/sequence/seq_common.hpp
@@ -15,6 +15,7 @@
 #ifndef SEQ_COMMON_HPP_
 #define SEQ_COMMON_HPP_
 
+#include <stdint.h>
 #include "k_range.hpp"
 
 typedef u_int64_t seq_element_type;

--- a/assembler/src/common/sequence/seq_common.hpp
+++ b/assembler/src/common/sequence/seq_common.hpp
@@ -16,7 +16,7 @@
 #define SEQ_COMMON_HPP_
 
 #include "k_range.hpp"
-#include <stdint.h>
+#include <cstdint>
 
 typedef uint64_t seq_element_type;
 

--- a/assembler/src/common/sequence/seq_common.hpp
+++ b/assembler/src/common/sequence/seq_common.hpp
@@ -16,7 +16,7 @@
 #define SEQ_COMMON_HPP_
 
 #include "k_range.hpp"
-#include <cstdint>
+#include <stdint.h>
 
 typedef uint64_t seq_element_type;
 


### PR DESCRIPTION
`<stdint.h>` needs to be included in some environments (e.g. Alpine Linux with `musl-dev` and `g++`) to have `u_int64_t` type defined

**EDIT:** Changed `<stdint.h>` to `<cstdint>`