### PR TITLE
Support python 3.10

### DIFF
--- a/assembler/src/spades_pipeline/stages/correction_stage.py
+++ b/assembler/src/spades_pipeline/stages/correction_stage.py
@@ -10,7 +10,6 @@
 import os
 import shutil
 import sys
-from distutils import dir_util
 from site import addsitedir
 
 from stages import stage
@@ -71,7 +70,9 @@ class CorrectionIterationStage(stage.Stage):
         dst_configs = os.path.join(self.cfg.output_dir, "configs")
         if os.path.isdir(dst_configs):
             shutil.rmtree(dst_configs)
-        dir_util.copy_tree(os.path.join(self.tmp_configs_dir, "corrector"), dst_configs, preserve_times=False)
+
+        self.copy_tree(os.path.join(self.tmp_configs_dir, "corrector"), dst_configs, preserve_times=False)
+
         cfg_file_name = os.path.join(dst_configs, "corrector.info")
 
         self.cfg.tmp_dir = support.get_tmp_dir(prefix="corrector_")

--- a/assembler/src/spades_pipeline/stages/error_correction_stage.py
+++ b/assembler/src/spades_pipeline/stages/error_correction_stage.py
@@ -10,7 +10,6 @@
 import os
 import shutil
 import sys
-from distutils import dir_util
 from site import addsitedir
 
 import commands_parser
@@ -63,10 +62,10 @@ class ECRunningToolStage(stage.Stage):
         if os.path.isdir(dst_configs):
             shutil.rmtree(dst_configs)
         if cfg.iontorrent:
-            dir_util.copy_tree(os.path.join(self.tmp_configs_dir, "ionhammer"), dst_configs, preserve_times=False)
+            self.copy_tree(os.path.join(self.tmp_configs_dir, "ionhammer"), dst_configs, preserve_times=False)
             cfg_file_name = os.path.join(dst_configs, "ionhammer.cfg")
         else:
-            dir_util.copy_tree(os.path.join(self.tmp_configs_dir, "hammer"), dst_configs, preserve_times=False)
+            self.copy_tree(os.path.join(self.tmp_configs_dir, "hammer"), dst_configs, preserve_times=False)
             cfg_file_name = os.path.join(dst_configs, "config.info")
 
         cfg.tmp_dir = support.get_tmp_dir(prefix="hammer_")

--- a/assembler/src/spades_pipeline/stages/pipeline.py
+++ b/assembler/src/spades_pipeline/stages/pipeline.py
@@ -9,7 +9,6 @@
 
 import os
 import shutil
-from distutils import dir_util
 
 import options_storage
 
@@ -17,15 +16,15 @@ class Pipeline(object):
     stages = []
 
     # copying configs before all computations (to prevent its changing at run time)
-    def copy_configs(self, cfg, spades_home, tmp_configs_dir):
+    def copy_configs(self, cfg, spades_home, tmp_configs_dir, stage):
         if os.path.isdir(tmp_configs_dir):
             shutil.rmtree(tmp_configs_dir)
         if not os.path.isdir(tmp_configs_dir):
             if options_storage.args.configs_dir:
-                dir_util.copy_tree(options_storage.args.configs_dir, tmp_configs_dir, preserve_times=False,
+                stage.copy_tree(options_storage.args.configs_dir, tmp_configs_dir, preserve_times=False,
                                    preserve_mode=False)
             else:
-                dir_util.copy_tree(os.path.join(spades_home, "configs"), tmp_configs_dir, preserve_times=False,
+                stage.copy_tree(os.path.join(spades_home, "configs"), tmp_configs_dir, preserve_times=False,
                                    preserve_mode=False)
 
     def add(self, stage):
@@ -37,7 +36,7 @@ class Pipeline(object):
             commands += stage.get_command(cfg)
         return commands
 
-    def generate_configs(self, cfg, spades_home, tmp_configs_dir):
+    def generate_configs(self, cfg, spades_home, tmp_configs_dir, stage):
         self.copy_configs(cfg, spades_home, tmp_configs_dir)
         for stage in self.stages:
             stage.generate_config(cfg)

--- a/assembler/src/spades_pipeline/stages/scaffold_correction_stage.py
+++ b/assembler/src/spades_pipeline/stages/scaffold_correction_stage.py
@@ -9,7 +9,6 @@
 
 import os
 import shutil
-from distutils import dir_util
 
 import commands_parser
 import options_storage
@@ -84,7 +83,7 @@ class ScaffoldCorrectionStage(stage.Stage):
             shutil.rmtree(data_dir)
         os.makedirs(data_dir)
 
-        dir_util.copy_tree(os.path.join(self.tmp_configs_dir, "debruijn"), dst_configs, preserve_times=False)
+        self.copy_tree(os.path.join(self.tmp_configs_dir, "debruijn"), dst_configs, preserve_times=False)
 
         scaffolds_file = os.path.join(latest, "scaffolds.fasta")
         if "read_buffer_size" in cfg.__dict__:

--- a/assembler/src/spades_pipeline/stages/spades_iteration_stage.py
+++ b/assembler/src/spades_pipeline/stages/spades_iteration_stage.py
@@ -9,7 +9,6 @@
 
 import os
 import shutil
-from distutils import dir_util
 
 import commands_parser
 import options_storage
@@ -140,8 +139,7 @@ class IterationStage(stage.Stage):
             if not os.path.isdir(data_dir):
                 os.makedirs(data_dir)
 
-            dir_util._path_created = {}  # see http://stackoverflow.com/questions/9160227/dir-util-copy-tree-fails-after-shutil-rmtree
-            dir_util.copy_tree(os.path.join(self.tmp_configs_dir, "debruijn"), dst_configs, preserve_times=False)
+            self.copy_tree(os.path.join(self.tmp_configs_dir, "debruijn"), dst_configs, preserve_times=False)
 
         if self.prev_K:
             additional_contigs_dname = os.path.join(cfg.output_dir, "K%d" % self.prev_K, "simplified_contigs")

--- a/assembler/src/spades_pipeline/stages/stage.py
+++ b/assembler/src/spades_pipeline/stages/stage.py
@@ -23,3 +23,20 @@ class Stage(object):
 
     def get_command(self, cfg):
         return []
+
+    # shutil.copyfile does not copy any metadata (time and permission), so one
+    # cannot expect preserve_mode = False and preserve_times = True to work.
+    def copy_tree(src, dst, preserve_times = True, preserve_mode = True):
+        if preserve_mode == False:
+            copy_fn = shutil.copyfile
+        else:
+            copy_fn = shutil.copy2
+
+        # shutil.copytree preserves the timestamp, so we must update it afterwards.
+        shutil.copytree(src, dst, copy_function = copy_fn, dirs_exist_ok = True)
+
+        if preserve_times == False:
+            for dirpath, _, filenames in os.walk(dst):
+                os.utime(dirpath, None)
+                for file in filenames:
+                    os.utime(os.path.join(dirpath, file), None)

--- a/assembler/src/spades_pipeline/support.py
+++ b/assembler/src/spades_pipeline/support.py
@@ -20,7 +20,10 @@ import sys
 import tempfile
 import traceback
 from platform import uname
-from distutils.version import LooseVersion
+try:
+    from packaging.version import Version
+except ModuleNotFoundError:
+    from distutils.version import LooseVersion as Version
 from os.path import abspath, expanduser, join
 
 import options_storage
@@ -115,7 +118,7 @@ def check_python_version():
             min_inc = max_inc = supported_versions
         max_exc = __next_version(max_inc)
         supported_versions_msg.append("Python%s: %s" % (major, supported_versions.replace('+', " and higher")))
-        if LooseVersion(min_inc) <= LooseVersion(current_version) < LooseVersion(max_exc):
+        if Version(min_inc) <= Version(current_version) < Version(max_exc):
             return True
     error("python version %s is not supported!\n"
           "Supported versions are %s" % (current_version, ", ".join(supported_versions_msg)))


### PR DESCRIPTION
distutils is deprecated and its use triggers DeprecationWarning which
make some Ubuntu autopkgtests fail: fix this by replacing distutils by
equivalent functions.

distutils.version is simply replaced with packaging.version.

distutils.copy_tree is a bit more complicated as preserve_mode/times
does not exist directly in shutil.copytree function.

Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>