### PR TITLE
Avoid expr substr in spades_compile.sh

### DIFF
--- a/assembler/spades_compile.sh
+++ b/assembler/spades_compile.sh
@@ -36,10 +36,10 @@ check_whether_OPTARG_is_an_integer() {
 }
 
 # return the argument first character
-str_head() { echo "$(expr substr "$1" 1 1)"; }
+str_head() { echo "${1::1}"; }
 
 # return the argument without the first character
-str_tail() { echo "$(expr substr "$1" 2 $((${#1}-1)))"; }
+str_tail() { echo "${1:1}"; }
 
 print_help() {
   echo


### PR DESCRIPTION
`expr substr` is not defined in posix and not implemented in MacOS /bin/expr. The much simpler bash substring expansion should be more widely compatible. It does work with MacOS' ancient /bin/bash.