### PR TITLE
Change GetUnique() return type from char to init8_t

### DIFF
--- a/src/common/kmer_index/extension_index/inout_mask.hpp
+++ b/src/common/kmer_index/extension_index/inout_mask.hpp
@@ -63,10 +63,10 @@ private:
         return unique[mask];
     }
 
-    static constexpr int8_t GetUnique(uint8_t mask) {
-        constexpr int8_t next[] =
-                { -1,  0,  1, -1,  2, -1, -1, -1,
-                  3, -1, -1, -1, -1, -1, -1, -1 };
+     static constexpr char GetUnique(uint8_t mask) {
+        constexpr char next[] =
+            {  UINT8_C(0xFF),  0,  1, UINT8_C(0xFF),  2, UINT8_C(0xFF), UINT8_C(0xFF), UINT8_C(0xFF),
+            3, UINT8_C(0xFF), UINT8_C(0xFF), UINT8_C(0xFF), UINT8_C(0xFF), UINT8_C(0xFF), UINT8_C(0xFF), UINT8_C(0xFF) };
         return next[mask];
     }
 

--- a/src/common/kmer_index/extension_index/inout_mask.hpp
+++ b/src/common/kmer_index/extension_index/inout_mask.hpp
@@ -63,8 +63,8 @@ private:
         return unique[mask];
     }
 
-    static constexpr char GetUnique(uint8_t mask) {
-        constexpr char next[] =
+    static constexpr int8_t GetUnique(uint8_t mask) {
+        constexpr int8_t next[] =
                 { -1,  0,  1, -1,  2, -1, -1, -1,
                   3, -1, -1, -1, -1, -1, -1, -1 };
         return next[mask];


### PR DESCRIPTION
`char` is unsigned on aarch64

Related to: https://github.com/ablab/spades/issues/1062#issuecomment-2019920641

With this change I was able to fully build SPAdes on Linux ARM64:
```
mgrigorov in 🌐 euler-arm-22 in spades on  next 
❯ file build/bin/*
build/bin/spades-bwa:                  ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=562164721589d0b609cd56ac36c3186706248059, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-convert-bin-to-fasta: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=74eda85d3b74b60020a4cd6657de655f3396fcde, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-core:                 ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=b5e24e4001f549108cab10b9745debf2da913be2, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-corrector-core:       ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=ead8c8c5f9a451a02bbb76b6841dc55f38b51fb5, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-gbuilder:             ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=b76e897b78e923d5cdda9c95463810bb42c40dfc, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-gfa-split:            ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=cae67bbe81c35d566da04826af6a04a85546d9fb, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-gmapper:              ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=5b8a3c6077b43c38e41d06c6d8aadc2ecbde9fcc, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-gsimplifier:          ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=7f0b67d6449d6fa4253d429e520358995c4e4f60, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-hammer:               ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=4368c59963ee313387a09cd00033531cbcc5e8e1, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-ionhammer:            ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=432aaf9b887ff8521ee073510fe47ffc379fff1b, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-kmer-estimating:      ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=ef045fa9bee7c8f061d2e133e584bebfaca731f3, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-kmercount:            ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=2f94a2b137de314fe0a12ccf4fbe47ee52afb5a0, for GNU/Linux 3.7.0, with debug_info, not stripped
build/bin/spades-read-filter:          ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=a7ebfa2a63cbebff0d29f490d570b5581e72b515, for GNU/Linux 3.7.0, with debug_info, not stripped

mgrigorov in 🌐 euler-arm-22 in spades on  next 
❯ ./build/bin/spades-bwa 

Program: bwa (alignment via Burrows-Wheeler transformation)
Version: 0.7.16a-r1185-dirty
Contact: Heng Li <lh3@sanger.ac.uk>

Usage:   bwa <command> [options]

Command: index         index sequences in the FASTA format
         mem           BWA-MEM algorithm
         fastmap       identify super-maximal exact matches
         pemerge       merge overlapping paired ends (EXPERIMENTAL)
         aln           gapped/ungapped alignment
         samse         generate alignment (single ended)
         sampe         generate alignment (paired ended)
         bwasw         BWA-SW for long queries

         shm           manage indices in shared memory
         fa2pac        convert FASTA to PAC format
         pac2bwt       generate BWT from PAC
         bwtupdate     update .bwt to the new format
         bwt2sa        generate SA from BWT and Occ

Note: To use BWA, you need to first index the genome with `bwa index'.
      There are three alignment algorithms in BWA: `mem', `bwasw', and
      `aln/samse/sampe'. If you are not sure which to use, try `bwa mem'
      first. Please `man ./bwa.1' for the manual.
```

If it does not cause regression for the supported platforms I'd be thankful if it is merged!