### PR TITLE
add missing <optional> header to src/projects/mts/kmer_multiplicity_counter.cpp

### DIFF
--- a/src/projects/mts/kmer_multiplicity_counter.cpp
+++ b/src/projects/mts/kmer_multiplicity_counter.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <memory>
 #include <algorithm>
+#include <optional>
 #include "getopt_pp/getopt_pp.h"
 #include "kmc_api/kmc_file.h"
 #include <pdqsort/pdqsort.h>


### PR DESCRIPTION
`src/projects/mts/kmer_multiplicity_counter.cpp` is missing `#include <optional>`.

Compiling with gcc/12.3.0 or /13.3.0, its lack results in errors like

```
/sw/bioinfo/spades/4.0.0/src/SPAdes-4.0.0/src/projects/mts/kmer_multiplicity_counter.cpp:104:18: error: 'optional' is not a member of 'std'
  104 |             std::optional<RtSeq> min_kmer;
      |                  ^~~~~~~~
/sw/bioinfo/spades/4.0.0/src/SPAdes-4.0.0/src/projects/mts/kmer_multiplicity_counter.cpp:27:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
```