### PR TITLE
Relax blaze cache size assertion

### DIFF
--- a/ext/include/blaze/blaze/system/CacheSize.h
+++ b/ext/include/blaze/blaze/system/CacheSize.h
@@ -74,7 +74,7 @@ constexpr size_t cacheSize = BLAZE_CACHE_SIZE;
 /*! \cond BLAZE_INTERNAL */
 namespace {
 
-BLAZE_STATIC_ASSERT( blaze::cacheSize > 100000UL && blaze::cacheSize < 100000000UL );
+BLAZE_STATIC_ASSERT( blaze::cacheSize > 100000UL && blaze::cacheSize < UINT64_C(10000000000) );
 
 }
 /*! \endcond */


### PR DESCRIPTION
 Likely we will not have CPUs with L3 caches of 10 Gb soon

Fixes #1362