### PR TITLE
fix: gcc new version

### DIFF
--- a/src/common/hmm/hmmmatcher.hpp
+++ b/src/common/hmm/hmmmatcher.hpp
@@ -11,6 +11,7 @@
 #include <llvm/ADT/iterator_range.h>
 
 #include <memory>
+#include <cstdint>
 #include "hmmer_fwd.h"
 
 namespace hmmer {

--- a/src/common/io/binary/binary.hpp
+++ b/src/common/io/binary/binary.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <unordered_map>
 #include <memory>
+#include <cstdint>
 
 namespace io {
 

--- a/src/common/io/reads/read_stream.hpp
+++ b/src/common/io/reads/read_stream.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <typeinfo>
 #include <typeindex>
+#include <cstdint>
 
 namespace io {
 


### PR DESCRIPTION
my gcc version

```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.1.1 20250425 (GCC) 
```