### PR TITLE
Fix two memory use errors detected by ASAN

### DIFF
--- a/ext/src/ssw/ssw_cpp.cpp
+++ b/ext/src/ssw/ssw_cpp.cpp
@@ -126,8 +126,8 @@ int CalculateNumberMismatch(
     int8_t const *query,
     const int& query_len) {
 
-  ref   += al->ref_begin;
-  query += al->query_begin;
+  ref   += (al->ref_begin > 0 ? al->ref_begin : 0);
+  query += (al->query_begin > 0 ? al->query_begin : 0);
   int mismatch_length = 0;
 
   std::vector<uint32_t> new_cigar;

--- a/src/common/modules/simplification/topological_edge_conditions.hpp
+++ b/src/common/modules/simplification/topological_edge_conditions.hpp
@@ -63,7 +63,7 @@ UniquePathLengthLowerBound(const Graph &g, size_t min_length) {
 template<class Graph>
 EdgePredicate<Graph>
 UniqueIncomingPathLengthLowerBound(const Graph &g, size_t min_length) {
-    return [&] (typename Graph::EdgeId e) {
+    return [&g, min_length] (typename Graph::EdgeId e) {
         typename Graph::VertexId v = g.EdgeStart(e);
         return g.CheckUniqueIncomingEdge(v) &&
                 UniquePathLengthLowerBound(g, min_length)(g.GetUniqueIncomingEdge(v));


### PR DESCRIPTION
 - SSW may return `-1` for reference alignment start coordinate (for unaligned case), causing read before buffer
 - `UniquePathLengthLowerBound` returned lambda that captured incoming argument `min_length` by reference