### PR TITLE
Add grid engine credentials attribute to SLURM executor

### DIFF
--- a/src/projects/spades/pipeline/spades_pipeline/executors/executor_slurm.py
+++ b/src/projects/spades/pipeline/spades_pipeline/executors/executor_slurm.py
@@ -27,6 +27,7 @@ class Executor(executor_base.ExecutorCluster):
     grid_engine_nodes = "--nodes={NNODES} --ntasks={NNODES}"
     grid_engine_kill_command = "scancel {JOB_NAME}"
     grid_engine_srun_args = "--cpus-per-task {NCPUS}"
+    grid_engine_credentials = "-p {QUEUE}"
 
     def join(self, job_name):
         log_file = options_storage.args.output_dir + "/spades.log"


### PR DESCRIPTION
fix the missing grid_engine_credentials bug:
spades/spades_pipeline/executors/executor_slurm.py", line 33, in join
    cmd += " " + self.grid_engine_credentials.format(QUEUE=options_storage.args.grid_queue)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Executor' object has no attribute 'grid_engine_credentials'